### PR TITLE
Fix volumes on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This allows you to :
 Just add these aliases to your ~/.bash_aliases in order to use ansible as it where installed on your computer.
 
 ```bash
-alias base_ansible='docker run -it --rm --volume $SSH_AUTH_SOCK:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent -v /etc/hosts:/etc/hosts:ro -v ${HOME}:${HOME}:ro -v ${HOME}/.ssh:/root/.ssh --env ANSIBLE_HOST_KEY_CHECKING=False -w ${PWD} kitpages/docker-ansible'
+alias base_ansible='docker run -it --rm --volume $SSH_AUTH_SOCK:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent -v /etc/hosts:/etc/hosts:ro -v ${PWD}:${PWD} -v ${HOME}/.ssh:/root/.ssh --env ANSIBLE_HOST_KEY_CHECKING=False -w ${PWD} kitpages/docker-ansible'
 alias ansible='base_ansible ansible'
 alias ansible-playbook='base_ansible ansible-playbook'
 alias ansible-vault='base_ansible ansible-vault'


### PR DESCRIPTION
We dont really need to mount $HOME in read only.

But we need to mount $PWD in read/write, for ansible-galaxy vendors, ansible.log, ...

```
➜ ansible-galaxy install -r requirements.yml --ignore-errors --force
[WARNING]: log file at ansible.log is not writeable and we cannot create it, aborting

- downloading role 'fail2ban', owned by tersmitten
- downloading role from https://github.com/Oefenweb/ansible-fail2ban/archive/v1.5.0.tar.gz
- extracting fail2ban to [...]/roles/fail2ban
 [WARNING]: - fail2ban was NOT installed successfully: Could not update files in [...]/roles/fail2ban: [Errno 30] Read-
only file system: '[...]/roles/fail2ban'
```
